### PR TITLE
Remove apply k8s target

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ edge_count=1
 
 To fire up the infrastructure execute the `apply` command with the desired modules. By default all modules will be created.
 ```
-rega apply --modules=[infra,k8s,all]
+rega apply --modules=[infra,all]
 ```
 
 Once the deployment is done, you can configure `kubectl` and explore the cluster:

--- a/rega.py
+++ b/rega.py
@@ -47,8 +47,8 @@ def version(image):
               envvar='REGA_PROVISIONER_IMG',
               help='Docker image used for provisioning')
 @click.option('-M', '--modules', default='all',
-              type=click.Choice(['infra', 'k8s', 'all']),
-              help='Options are: "infra", "k8s" and "all"')
+              type=click.Choice(['infra', 'all']),
+              help='Options are: "infra" and "all"')
 def apply(image, modules):
     """Applies the Terraform plan to spawn the desired resources."""
     logging.info("""Applying setup using mode {}""".format(modules))
@@ -136,7 +136,7 @@ def run_in_container(commands, image):
 
 
 def apply_tf_modules(target, image):
-    if target == 'infra' or target == 'k8s':
+    if target == 'infra':
         terraform_apply(get_tf_modules(target), image)
     elif target == 'all':
         infra_exit_code = terraform_apply(get_tf_modules('infra'), image)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='rega',
-    version='0.4.0',
+    version='0.4.1',
     packages=find_packages(),
     py_modules=['rega'],
     include_package_data=True,


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [x] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
As dicsussed in #10 , the `k8s` target does not make sense for the `apply` stage, as it will have the same behaviour as `all`, but without properly propagating exit codes.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Removed `k8s` target from apply CLI option.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->
#9 

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

Updated CLI now only allows for `apply -M all | infra`

```
$rega apply --help
Usage: rega apply [OPTIONS]

  Applies the Terraform plan to spawn the desired resources.

Options:
  -I, --image TEXT           Docker image used for provisioning
  -M, --modules [infra|all]  Options are: "infra" and "all"
  --help
```
