### PR TITLE
Adds prettytable==0.7.2 to the install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ setup(
         'docker==4.0.1',
         'cryptography==2.7',
         'flake8==3.7.7',
-        'PyYAML==5.1.1'
+        'PyYAML==5.1.1',
+        'prettytable==0.7.2'
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
### Describe the pull request
- [X] Bug fix

### Pull request long description

When installing rega in a fresh environment and then running it the following happens:

```bash
$ rega --help
Traceback (most recent call last):
  File "<PATH>/venv/bin/rega", line 6, in <module>
    from rega import main
  File "<PATH>/venv/lib/python3.6/site-packages/rega.py", line 15, in <module>
    from prettytable import PrettyTable
ModuleNotFoundError: No module named 'prettytable'
```


### Changes made
`prettytable==0.7.2` added to `install_requires` in `setup.py`.