### PR TITLE
Remove ":" in Pull Request Template headers

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 <!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
 <!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->
 
-### Describe the pull request:
+### Describe the pull request
 <!-- Replace [ ] with [x] to select options. -->
 - [ ] Bug fix
 - [ ] Functional change
@@ -12,28 +12,28 @@
 - [ ] Documentation change
 - [ ] Language translation
 
-### Pull request long description:
+### Pull request long description
 <!-- Describe your pull request in detail. -->
 
-### Changes made:
+### Changes made
 <!-- Enumerate the changes with 1), 2), 3) etc. -->
 <!-- Ensure the test cases are updated if needed. -->
 
-### Related issues:
+### Related issues
 <!-- Reference issues with #<issue-num>. -->
 <!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->
 
-### Additional information:
+### Additional information
 <!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
 
-### Release note:
+### Release note
 <!-- Describe if this change needs a release note present in CHANGELOG.md. -->
 <!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
 
-### Documentation change:
+### Documentation change
 <!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
 <!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
 <!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
 
-### Mentions:
+### Mentions
 <!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->


### PR DESCRIPTION
### Describe the pull request
- [X] Code cleanup


### Pull request long description

Colons do not belong in titles, so I removed them.