### PR TITLE
Limit openstack opened ports to certain CIDR blocks

### DIFF
--- a/rega/deployment-template/main.j2
+++ b/rega/deployment-template/main.j2
@@ -29,7 +29,7 @@ module "master" {
   image_name         = var.image_name
   cloud_init_data    = var.cloud_init_data
   network_name       = module.network.network_name
-  secgroup_name      = module.secgroup.secgroup_name
+  secgroups_name     = [module.secgroup.secgroup_name, var.secgroups]
   floating_ip_pool   = var.floating_ip_pool
   ssh_user           = var.ssh_user
   ssh_key            = var.ssh_key
@@ -47,7 +47,7 @@ module "service" {
   image_name         = var.image_name
   cloud_init_data    = var.cloud_init_data
   network_name       = module.network.network_name
-  secgroup_name      = module.secgroup.secgroup_name
+  secgroups_name     = [module.secgroup.secgroup_name, var.secgroups]
   floating_ip_pool   = var.floating_ip_pool
   ssh_user           = var.ssh_user
   ssh_key            = var.ssh_key
@@ -65,7 +65,7 @@ module "edge" {
   image_name         = var.image_name
   cloud_init_data    = var.cloud_init_data
   network_name       = module.network.network_name
-  secgroup_name      = module.secgroup.secgroup_name
+  secgroups_name     = [module.secgroup.secgroup_name, var.secgroups]
   floating_ip_pool   = var.floating_ip_pool
   ssh_user           = var.ssh_user
   ssh_key            = var.ssh_key

--- a/rega/deployment-template/modules/node/main.tf
+++ b/rega/deployment-template/modules/node/main.tf
@@ -12,7 +12,7 @@ resource "openstack_compute_instance_v2" "instance" {
 
   user_data = data.template_file.cloud_init.rendered
   config_drive = "true"
-  security_groups = flatten([var.secgroup_name])
+  security_groups = flatten(var.secgroups_name)
 }
 
 # Allocate floating IPs (if required)

--- a/rega/deployment-template/modules/node/variables.tf
+++ b/rega/deployment-template/modules/node/variables.tf
@@ -34,7 +34,7 @@ variable "network_name" {
   description = "Name of the network to attach this node to"
 }
 
-variable "secgroup_name" {
+variable "secgroups_name" {
   description = "Name of the security group for this node"
 }
 

--- a/rega/deployment-template/modules/secgroup/main.tf
+++ b/rega/deployment-template/modules/secgroup/main.tf
@@ -47,7 +47,7 @@ resource "openstack_networking_secgroup_rule_v2" "ingress_tcp" {
 }
 
 resource "openstack_networking_secgroup_rule_v2" "ingress_udp" {
-  count = length(var.allowed_ingress_udp)
+  count = length(local.expanded_udp_ingresses)
 
   direction         = "ingress"
   ethertype         = "IPv4"

--- a/rega/deployment-template/modules/secgroup/variables.tf
+++ b/rega/deployment-template/modules/secgroup/variables.tf
@@ -3,14 +3,14 @@ variable "name_prefix" {
 }
 
 variable "allowed_ingress_tcp" {
-  type        = list(string)
+  type        = map(list(number))
   description = "Allowed TCP ingress traffic"
-  default     = []
+  default     = {}
 }
 
 variable "allowed_ingress_udp" {
-  type        = list(string)
+  type        = map(list(number))
   description = "Allowed UDP ingress traffic"
-  default     = []
+  default     = {}
 }
 

--- a/rega/deployment-template/terraform.tfvars
+++ b/rega/deployment-template/terraform.tfvars
@@ -20,7 +20,8 @@ kubernetes_version="v1.14.3-rancher1-1"
 
 # Security groups
 allowed_ingress_tcp={
-  "130.238.0.0/16" = [22, 6443, 80, 443, 10250] # Uppsala University
-  "130.239.0.0/16" = [22, 6443, 80, 443, 10250] # Umeå
-  "129.16.0.0/16"  = [22, 6443, 80, 443, 10250] # Chalmers ### ipinfo.io
+  # These are the ports you need to work with kubernetes and rancher from your
+  # machine.
+  #'<YOUR CIDR>' = [22, 6443, 80, 443, 10250]
 }
+allowed_ingress_udp={}

--- a/rega/deployment-template/terraform.tfvars
+++ b/rega/deployment-template/terraform.tfvars
@@ -25,3 +25,4 @@ allowed_ingress_tcp={
   #'<YOUR CIDR>' = [22, 6443, 80, 443, 10250]
 }
 allowed_ingress_udp={}
+secgroups = []

--- a/rega/deployment-template/terraform.tfvars
+++ b/rega/deployment-template/terraform.tfvars
@@ -18,3 +18,9 @@ edge_count=1
 # Please check that the Kubernetes version is RKE 0.2.x compliant
 kubernetes_version="v1.14.3-rancher1-1" 
 
+# Security groups
+allowed_ingress_tcp={
+  "130.238.0.0/16" = [22, 6443, 80, 443, 10250] # Uppsala University
+  "130.239.0.0/16" = [22, 6443, 80, 443, 10250] # Umeå
+  "129.16.0.0/16"  = [22, 6443, 80, 443, 10250] # Chalmers ### ipinfo.io
+}

--- a/rega/deployment-template/variables.tf
+++ b/rega/deployment-template/variables.tf
@@ -101,16 +101,19 @@ variable "edge_assign_floating_ip" {
   default     = true
 }
 
+# Type for this one and next is supposed to be map(list(number)), but then the
+# pyhcl library can't parse the tf file, so for now it will stay like this, the
+# real type constraint can be found in modules/secgroup/variables.tf
 variable "allowed_ingress_tcp" {
-  type        = "list"
-  description = "Allowed TCP ingress traffic"
-  default     = [22, 6443, 80, 443, 10250]
+  type        = "map"
+  description = "Allowed TCP ingress traffic. A map with CIDR keys and values are the list of ports that should be open to that block."
+  default     = {}
 }
 
 variable "allowed_ingress_udp" {
-  type        = "list"
-  description = "Allowed UDP ingress traffic"
-  default     = []
+  type        = "map"
+  description = "Allowed UDP ingress traffic. A map with CIDR keys and values are the list of ports that should be open to that block."
+  default     = {}
 }
 
 variable "os_username" {

--- a/rega/deployment-template/variables.tf
+++ b/rega/deployment-template/variables.tf
@@ -116,6 +116,12 @@ variable "allowed_ingress_udp" {
   default     = {}
 }
 
+variable "secgroups" {
+  type        = "list"
+  description = "Extra security groups to assign to compute nodes"
+  default     = []
+}
+
 variable "os_username" {
   description = "Openstack user name"
 }


### PR DESCRIPTION


### Describe the pull request
- [X] Functional change
- [X] New feature

### Pull request long description
It's now possible to open ports to only certain IP blocks instead of to
the world. Huge security improvement if I may say so.

Format is a map with the CIDR as key and a list of ports to open as
values, for example:

```
allowed_ingress_tcp={
  "10.0.0.0/8" = [22, 6443, 80, 443, 10250],
  "0.0.0.0/0"  = [443]
}
```