### PR TITLE
Refactor

### DIFF
--- a/rega/cmd.py
+++ b/rega/cmd.py
@@ -367,3 +367,7 @@ def filter_vars(seq):
         elif key.startswith('OS_'):
             yield key + '=' + val
             yield 'TF_VAR_' + key.lower() + '=' + val
+
+
+if __name__ == '__main__':
+    main()

--- a/rega/cmd.py
+++ b/rega/cmd.py
@@ -128,7 +128,7 @@ def download_image(client):
     try:
         client.images.pull(DOCKER_IMAGE)
     except docker.errors.APIError:
-        print("### ERROR ### Unable to pull the image {}. Does it exist?".format(DOCKER_IMAGE))
+        sys.stderr.write("### ERROR ### Unable to pull the image {}. Does it exist?\n".format(DOCKER_IMAGE))
         sys.exit(1)
 
 

--- a/rega/cmd.py
+++ b/rega/cmd.py
@@ -42,7 +42,6 @@ def init(directory, image):
               envvar='REGA_PROVISIONER_IMG')
 def version(image):
     """Outputs the version of the target provisioning container along with the original and current package versions."""
-    check_environment()
 
     with open('.version', 'r') as version_file:
         env_package = version_file.readline()
@@ -67,7 +66,6 @@ def version(image):
 def plan(image, modules, backend, config):
     """Creates a Terraform execution plan with the necessary actions to achieve the desired state."""
     logging.info("""Creating execution plan for {} modules""".format(modules))
-    check_environment()
     check_version(PACKAGE_VERSION)
     terraform_plan(modules, image, backend, config)
 
@@ -87,7 +85,6 @@ def plan(image, modules, backend, config):
 def apply(image, modules, backend, config):
     """Applies the Terraform plan to spawn the desired resources."""
     logging.info("""Applying setup using mode {}""".format(modules))
-    check_environment()
     check_version(PACKAGE_VERSION)
     apply_tf_modules(modules, image, backend, config)
 
@@ -103,7 +100,6 @@ def destroy(image, modules):
     """Releases the previously requested resources."""
     logging.info("""Destroying the infrastructure using mode {}""".format(modules))
     tf_modules = get_tf_modules(modules)
-    check_environment()
     check_version(PACKAGE_VERSION)
     run_in_container(['terraform destroy -force {}'.format(tf_modules)], image)
 
@@ -116,7 +112,6 @@ def destroy(image, modules):
 def terraform(extra_args, image):
     """Executes the terraform command in the provisioner container with the provided args."""
     logging.info("""Running terraform with arguments: {}""".format(extra_args))
-    check_environment()
     check_version(PACKAGE_VERSION)
     run_in_container(['terraform {}'.format(extra_args)], image)
 
@@ -129,7 +124,6 @@ def terraform(extra_args, image):
 def openstack(extra_args, image):
     """Executes the openstack command in the provisioner container with the provided args."""
     logging.info("""Running openstack with arguments: {}""".format(extra_args))
-    check_environment()
     check_version(PACKAGE_VERSION)
     run_in_container(['openstack {}'.format(extra_args)], image)
 
@@ -141,7 +135,6 @@ def openstack(extra_args, image):
               help='Docker image used for provisioning')
 def provision(image, extra_args):
     """Executes the Ansible playbook specified as an argument."""
-    check_environment()
     check_version(PACKAGE_VERSION)
     generate_vars_file()
     run_ansible(extra_args, image)
@@ -161,6 +154,8 @@ def download_image(client, image):
 
 def run_in_container(commands, image):
     """Executes a sequence of shell commands in a Docker container."""
+    check_environment()
+
     client = docker.from_env()
     download_image(client, image)
     env = list(filter_vars(os.environ))

--- a/rega/cmd.py
+++ b/rega/cmd.py
@@ -96,17 +96,22 @@ def destroy(modules):
     run_in_container(['terraform destroy -force {}'.format(tf_modules)])
 
 
-@main.command('terraform')
-@click.argument('extra_args')
+def _fix_extra_args(ctx, param, value):
+    """Callback to make sure the extra_args is a string and not a tuple"""
+    return " ".join(value)
+
+
+@main.command('terraform', context_settings={"ignore_unknown_options": True})
+@click.argument('extra_args', nargs=-1, type=click.UNPROCESSED, callback=_fix_extra_args)
 def terraform(extra_args):
     """Executes the terraform command in the provisioner container with the provided args."""
     logging.info("""Running terraform with arguments: %s""", extra_args)
     check_version(PACKAGE_VERSION)
-    run_in_container(['terraform {}'.format(extra_args)])
+    run_in_container([f'terraform {extra_args}'])
 
 
-@main.command('openstack')
-@click.argument('extra_args')
+@main.command('openstack', context_settings={"ignore_unknown_options": True})
+@click.argument('extra_args', nargs=-1, type=click.UNPROCESSED, callback=_fix_extra_args)
 def openstack(extra_args):
     """Executes the openstack command in the provisioner container with the provided args."""
     logging.info("""Running openstack with arguments: %s""", extra_args)

--- a/rega/cmd.py
+++ b/rega/cmd.py
@@ -120,12 +120,12 @@ def openstack(extra_args):
 
 
 @main.command('provision')
-@click.argument('extra_args')
-def provision(extra_args):
+@click.argument('playbook')
+def provision(playbook):
     """Executes the Ansible playbook specified as an argument."""
     check_version(PACKAGE_VERSION)
     generate_vars_file()
-    run_ansible(extra_args)
+    run_ansible(playbook)
 
 
 def download_image(client):

--- a/rega/cmd.py
+++ b/rega/cmd.py
@@ -149,6 +149,9 @@ def provision(image, extra_args):
 
 def download_image(client, image):
     """Attempts to download the target Docker image."""
+    if client.images.get(image):
+        # We already have the image, won't even try to pull it
+        return
     try:
         client.images.pull(image)
     except docker.errors.APIError:

--- a/rega/cmd.py
+++ b/rega/cmd.py
@@ -34,8 +34,6 @@ def main(image):
 def init(directory):
     """Initialises a new REGA environment."""
     logging.info("""Initilising a new environment in %s""", directory)
-    client = docker.from_env()
-    download_image(client)
     create_deployment(directory)
     logging.info("""Environment initialised. Navigate to the %s folder and update the terraform.tfvars file with your configuration""", directory)
 

--- a/rega/cmd.py
+++ b/rega/cmd.py
@@ -164,7 +164,8 @@ def run_in_container(commands):
     )
 
     for line in runner.logs(stream=True, follow=True):
-        print(line.decode())
+        # No need to add newlines since line already has them, so end="".
+        print(line.decode(), end="")
 
     result = runner.wait()
     exit_code = result.get('StatusCode', 1)


### PR DESCRIPTION
### Describe the pull request
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [X] Functional change
- [ ] New feature
- [X] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description
A lot of very small changes to improve stuff and make the program easier to use and navigate, I recommend checking this one commit at a time since every commit is basically one self-contained thing.

### Changes made
These are the commits, with short explanations where needed. Even more information can be found in the commit messages.

- **Only download docker images in case it's missing localy**
- **Moved calls to check_environment into run_container()**
  Almost all commands run this function, so putting it in a common place made more sense to me.
- **Added call to main() in case file is called directly**
  This simplifies development and testing a lot e.g. `python rke-openstack/rega/cmd.py provision`
- **Fix a bunch of pylint complaints**
  I ran pylint and corrected some of the warnings
- **Move image CLI selection to main group**
  Instead of having an `--image` argument for each command, this is now an option on the toplevel command.
- **Can run openstack/terraform with --options now**
  It was cumbersome to run the executables inside the docker image. One had to quote the commandline in cases where multiple words were used (see the commit).
- **Remove unnecesary newlines when showing underlying command output**
- **Changed provision subcommand argument to playbook from extra_args**
- **Moved call to check_version and improved docstring**
  This is similar to the _check_environment_ change above
- **Don't download docker image when initializing**
  I see no point in doing that here
- **Error printing should be to stderr**
  Just one instance where error was printed on `stdout`.