### PR TITLE
Remove do_check_version ref

### DIFF
--- a/rega/cmd.py
+++ b/rega/cmd.py
@@ -234,7 +234,7 @@ def run_init_scripts(directory):
 
 def clone_deployment_templates(repository, branch, directory):
     """Clone deployment template repo into new directory"""
-    run_in_container([f'git clone --branch={branch} {repository} {directory}'], do_check_version=False)
+    run_in_container([f'git clone --branch={branch} {repository} {directory}'])
 
 
 def generate_ssh_keys(directory):


### PR DESCRIPTION
This arg is no longer necessary since we now check that in the entrypoint

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description
<!-- Describe your pull request in detail. -->
do_check_version argument was removed from run_in_container call, as it is now handled in main entrypoint.
