### PR TITLE
Update info about default branch

### DIFF
--- a/rega/cmd.py
+++ b/rega/cmd.py
@@ -74,7 +74,7 @@ def main(image):
 @click.option('-r', '--repository', default='https://github.com/NBISweden/rega-templates.git',
               help="Specify the repo to use as a template for the infrastructure")
 @click.option('-b', '--branch', default=f"master",
-              help=f"The branch to checkout from the repo, default is v{PACKAGE_VERSION}")
+              help=f"The branch to checkout from the repo, default is master")
 @click.argument('directory')
 def init(repository, branch, directory):
     """Initialise a new REGA environment."""


### PR DESCRIPTION
Currently we use master as default branch from the rega-templates repo

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [x] Documentation change
- [ ] Language translation

### Pull request long description
<!-- Describe your pull request in detail. -->
Update info about default branch. Master is pulled by default.
