### PR TITLE
Do not use capture_output to work with python 3.6

### DIFF
--- a/rega/cmd.py
+++ b/rega/cmd.py
@@ -212,7 +212,7 @@ def run_in_container(commands):
     env = list(filter_vars(os.environ))
 
     top_level_dir = subprocess.run(f'git rev-parse --show-toplevel'.split(' '),
-                                   capture_output=True,
+                                   stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                                    encoding='utf-8')
 
     mount_directory = top_level_dir.stdout.strip('\n')


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description
<!-- Describe your pull request in detail. -->
Do not use functionality from python 3.7 to work with older (including standard installs on many systems such as Ubuntu bionic.

### Changes made
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. changed use of `capture_output=True` for `subprocess.run`to explicit specification of `stdout`, `stderr`.

